### PR TITLE
fixing SQL Server URL creation. This way works with Synapse too.

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -606,7 +606,7 @@ class SQLDbTool(BaseTool):
     def _run(self, query: str) -> str:
         db_config = {
             'drivername': 'mssql+pyodbc',
-            'username': os.environ["SQL_SERVER_USERNAME"] +'@'+ os.environ["SQL_SERVER_NAME"],
+            'username': os.environ["SQL_SERVER_USERNAME"],
             'password': os.environ["SQL_SERVER_PASSWORD"],
             'host': os.environ["SQL_SERVER_NAME"],
             'port': 1433,


### PR DESCRIPTION
Fixing the URL creation to also accepts Synapse. SQLAlchemy fixes the URL encoding not needing this '@'