### PR TITLE
update azd to create App Reg and SP before running

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -8,7 +8,7 @@
 name: Azure-Cognitive-Search-Azure-OpenAI-Accelerator
 
 hooks:
-  preprovision:
+  preup:
     windows:
       shell: pwsh
       run: ./infra/scripts/CreatePrerequisites.ps1
@@ -17,6 +17,17 @@ hooks:
     posix:
       shell: pwsh
       run: ./infra/scripts/CreatePrerequisites.ps1
+      interactive: true
+      continueOnError: false
+  preprovision:
+    windows:
+      shell: pwsh
+      run: ./infra/scripts/CreateAppRegistration.ps1
+      interactive: true
+      continueOnError: false
+    posix:
+      shell: pwsh
+      run: ./infra/scripts/CreateAppRegistration.ps1
       interactive: true
       continueOnError: false
   postprovision:


### PR DESCRIPTION
This pull request adds new preup and preprovision hooks in the `azure.yaml` file for both Windows and POSIX environments. These hooks run PowerShell scripts before provisioning, with different configurations for each environment.

* <a href="diffhunk://#diff-1ba5bd52036276068bc787a1be3dfa49aa920317ab02fa460c99246a78e588f3L11-R11">`azure.yaml`</a>: Added new preup and preprovision hooks for both Windows and POSIX environments. <a href="diffhunk://#diff-1ba5bd52036276068bc787a1be3dfa49aa920317ab02fa460c99246a78e588f3L11-R11">[1]</a> <a href="diffhunk://#diff-1ba5bd52036276068bc787a1be3dfa49aa920317ab02fa460c99246a78e588f3R22-R32">[2]</a>