### PR TITLE
notebook 09 - Added os import statement 

### DIFF
--- a/09-BingChatClone.ipynb
+++ b/09-BingChatClone.ipynb
@@ -40,6 +40,7 @@
     }
    ],
    "source": [
+    "import os\n"
     "import requests\n",
     "from typing import Dict, List, Optional, Type\n",
     "import asyncio\n",

--- a/09-BingChatClone.ipynb
+++ b/09-BingChatClone.ipynb
@@ -40,7 +40,7 @@
     }
    ],
    "source": [
-    "import os\n"
+    "import os\n",
     "import requests\n",
     "from typing import Dict, List, Optional, Type\n",
     "import asyncio\n",


### PR DESCRIPTION
The `os` reference step was failing without this import. It was using the devcontainer instance.