### PR TITLE
Fix for typo in variable name

### DIFF
--- a/03-Quering-AOpenAI.ipynb
+++ b/03-Quering-AOpenAI.ipynb
@@ -854,7 +854,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "index_name = \"cogsrch-index-files\"\n",
+    "index1_name = \"cogsrch-index-files\"\n",
     "index2_name = \"cogsrch-index-csv\"\n",
     "indexes = [index1_name, index2_name]"
    ]


### PR DESCRIPTION
The variable name `index_name` is incorrect and should be `index1_name`. It will work for most users since `index1_name` is defined separately in an earlier cell of the notebook. I just happened to pause and resume my compute in between the two cells and noticed the error.